### PR TITLE
Updated Cake.Core to 0.23.0 and .NET Framework to 4.6

### DIFF
--- a/src/Cake.AppleSimulator.Tests/Cake.AppleSimulator.Tests.csproj
+++ b/src/Cake.AppleSimulator.Tests/Cake.AppleSimulator.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.AppleSimulator.Tests</RootNamespace>
     <AssemblyName>Cake.AppleSimulator.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -54,9 +54,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Cake.Core">
-      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
-    </Reference>
     <Reference Include="xunit.abstractions">
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
@@ -69,14 +66,17 @@
     <Reference Include="xunit.execution.desktop">
       <HintPath>..\packages\xunit.extensibility.execution.2.2.0-beta4-build3444\lib\net45\xunit.execution.desktop.dll</HintPath>
     </Reference>
-    <Reference Include="Cake.Testing">
-      <HintPath>..\packages\Cake.Testing.0.17.0\lib\net45\Cake.Testing.dll</HintPath>
-    </Reference>
     <Reference Include="FluentAssertions.Core">
       <HintPath>..\packages\FluentAssertions.4.18.0\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
     <Reference Include="FluentAssertions">
       <HintPath>..\packages\FluentAssertions.4.18.0\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="Cake.Core">
+      <HintPath>..\packages\Cake.Core.0.23.0\lib\net46\Cake.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Cake.Testing">
+      <HintPath>..\packages\Cake.Testing.0.23.0\lib\net46\Cake.Testing.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Cake.AppleSimulator.Tests/packages.config
+++ b/src/Cake.AppleSimulator.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.17.0" targetFramework="net452" />
-  <package id="Cake.Testing" version="0.17.0" targetFramework="net452" />
+  <package id="Cake.Core" version="0.23.0" targetFramework="net46" />
+  <package id="Cake.Testing" version="0.23.0" targetFramework="net46" />
   <package id="FluentAssertions" version="4.18.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net452" />

--- a/src/Cake.AppleSimulator/Cake.AppleSimulator.csproj
+++ b/src/Cake.AppleSimulator/Cake.AppleSimulator.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cake.AppleSimulator</RootNamespace>
     <AssemblyName>Cake.AppleSimulator</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -48,7 +48,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Cake.Core">
-      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
+      <HintPath>..\packages\Cake.Core.0.23.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Cake.AppleSimulator/packages.config
+++ b/src/Cake.AppleSimulator/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.17.0" targetFramework="net452" />
+  <package id="Cake.Core" version="0.23.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
I've updated the Cake version from one of my projects to 0.23.0 and I'm getting the following error when using this addin.

`Error: The assembly 'Cake.AppleSimulator, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null' 
is referencing an older version of Cake.Core (0.17.0). 
This assembly need to reference at least Cake.Core version 0.22.0. `

I've also updated the .NET Framework version as Cake.Core 0.23.0 requires .NET Framework 4.6
