### PR TITLE
(build) Exclude FluentAssertions from CodeCoverage

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -21,7 +21,7 @@ BuildParameters.PrintParameters(Context);
 ToolSettings.SetToolSettings(context: Context,
                             dupFinderExcludePattern: new string[] {
                                 BuildParameters.RootDirectoryPath + "/Cake.AppleSimulator.Tests/*.cs" },
-                            testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* -[FakeItEasy]*",
+                            testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* -[FakeItEasy]* -[FluentAssertions]*",
                             testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
                             testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs;*TestProjects*");
 Build.RunDotNetCore();


### PR DESCRIPTION
By default, when uploading to coveralls.io, it will attempt to upload
all .cs files for "things" that it has inspected.  FluentAssertions is
referenced in the codebase, and therefore OpenCover will trying to
include it.  Adding this to the array of exclusions, means that it
won't be inspected going forward.